### PR TITLE
fix:修复3.0.0.504框架版本下组件编译失败的问题

### DIFF
--- a/harmony/safe_area/src/main/cpp/SafeAreaProviderComponentInstance.cpp
+++ b/harmony/safe_area/src/main/cpp/SafeAreaProviderComponentInstance.cpp
@@ -21,8 +21,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+#include <sys/param.h>
 #include "SafeAreaProviderComponentInstance.h"
 #include "TurboModuleRequest.h"
+
 namespace rnoh {
 
     SafeAreaProviderComponentInstance::SafeAreaProviderComponentInstance(Context context)


### PR DESCRIPTION
# Summary

- 修复3.0.0.504框架版本下组件编译失败，报错MAX和MIN未定义的问题
- close：#28

## Test Plan
![image](https://github.com/user-attachments/assets/8f273c83-f093-4ce7-88fd-cb2547d24e43)

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
